### PR TITLE
fix #12: Importing apispec only if OpenAPIResponse is used

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,10 @@ replace = * **Version:** {new_version}
 
 [tool:pytest]
 minversion = 3
-addopts = --cov-config=setup.cfg --cov=starlette_api
+filterwarnings =
+    ignore::DeprecationWarning
+addopts =
+    #--cov-config=setup.cfg --cov=starlette_api
 norecursedirs = 
 	*settings*
 	*urls*

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,7 @@ replace = * **Version:** {new_version}
 
 [tool:pytest]
 minversion = 3
-filterwarnings =
-    ignore::DeprecationWarning
-addopts =
-    #--cov-config=setup.cfg --cov=starlette_api
+addopts = --cov-config=setup.cfg --cov=starlette_api
 norecursedirs = 
 	*settings*
 	*urls*

--- a/starlette_api/schemas.py
+++ b/starlette_api/schemas.py
@@ -32,6 +32,7 @@ class OpenAPIResponse(schemas.OpenAPIResponse):
         assert isinstance(content, dict), "The schema passed to OpenAPIResponse should be a dictionary."
 
         from apispec.core import YAMLDumper
+
         return yaml.dump(content, default_flow_style=False, Dumper=YAMLDumper).encode("utf-8")
 
 

--- a/starlette_api/schemas.py
+++ b/starlette_api/schemas.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from string import Template
 
 import marshmallow
-from apispec.core import YAMLDumper
 from starlette import routing, schemas
 from starlette.responses import HTMLResponse
 
@@ -29,8 +28,10 @@ __all__ = ["OpenAPIResponse", "SchemaGenerator", "SchemaMixin"]
 class OpenAPIResponse(schemas.OpenAPIResponse):
     def render(self, content: typing.Any) -> bytes:
         assert yaml is not None, "`pyyaml` must be installed to use OpenAPIResponse."
+        assert apispec is not None, "`apispec` must be installed to use OpenAPIResponse."
         assert isinstance(content, dict), "The schema passed to OpenAPIResponse should be a dictionary."
 
+        from apispec.core import YAMLDumper
         return yaml.dump(content, default_flow_style=False, Dumper=YAMLDumper).encode("utf-8")
 
 


### PR DESCRIPTION
I wanted to fix the tests but I think it's not a good solution because you install it into `poetry.lock`.